### PR TITLE
[Feature] Invalid inupt check in ssd_read & write ERROR message to ssd_output.txt

### DIFF
--- a/ssd.py
+++ b/ssd.py
@@ -1,6 +1,8 @@
 class SSD():
     def read_ssd(self, index):
         if not self.check_input_validity(index):
+            with open("ssd_output.txt", "w") as file:
+                file.write("ERROR")
             raise ValueError("ERROR")
 
         ssd_nand_txt = ""
@@ -15,6 +17,8 @@ class SSD():
     # write 함수
     def write_ssd(self, lba, value):
         if not self.check_input_validity(lba, value):
+            with open("ssd_output.txt", "w") as file:
+                file.write("ERROR")
             raise ValueError("ERROR")
 
         # ssd_nand.txt 파일 읽기

--- a/ssd.py
+++ b/ssd.py
@@ -1,8 +1,6 @@
 class SSD():
     def read_ssd(self, index):
-        if type(index) is not int:
-            raise ValueError("ERROR")
-        if not 0 <= index < 100:
+        if not self.check_input_validity(index):
             raise ValueError("ERROR")
 
         ssd_nand_txt = ""
@@ -34,7 +32,7 @@ class SSD():
         with open("ssd_output.txt", 'w', encoding='utf-8') as file:
             file.write("")
 
-    def check_input_validity(self, lba, value):
+    def check_input_validity(self, lba, value = 0x00000000):
         if type(lba) is not int:
             return False
         if type(value) is not int:

--- a/ssd.py
+++ b/ssd.py
@@ -1,5 +1,10 @@
 class SSD():
     def read_ssd(self, index):
+        if type(index) is not int:
+            raise ValueError("ERROR")
+        if not 0 <= index < 100:
+            raise ValueError("ERROR")
+
         ssd_nand_txt = ""
         with open("ssd_nand.txt", 'r', encoding='utf-8') as file:
             ssd_nand_txt = file.read()

--- a/test_ssd.py
+++ b/test_ssd.py
@@ -50,6 +50,8 @@ def test_ssd_read_error_minus_index():
         ssd.read_ssd(-1)
     with pytest.raises(ValueError, match="ERROR"):
         ssd.read_ssd(-10)
+    with open("ssd_output.txt", 'r', encoding='utf-8') as file:
+        assert file.read() == "ERROR"
 
 
 def test_ssd_read_error_index_above_99():
@@ -60,12 +62,16 @@ def test_ssd_read_error_index_above_99():
         ssd.read_ssd(1000)
     with pytest.raises(ValueError, match="ERROR"):
         ssd.read_ssd(10000)
+    with open("ssd_output.txt", 'r', encoding='utf-8') as file:
+        assert file.read() == "ERROR"
 
 
 def test_ssd_read_error_not_digit():
     ssd = SSD()
     with pytest.raises(ValueError, match="ERROR"):
         ssd.read_ssd("abc")
+    with open("ssd_output.txt", 'r', encoding='utf-8') as file:
+        assert file.read() == "ERROR"
 
 
 def test_ssd_write_error_minus_index():
@@ -74,6 +80,8 @@ def test_ssd_write_error_minus_index():
         ssd.write_ssd(-1, 0x00000000)
     with pytest.raises(ValueError, match="ERROR"):
         ssd.write_ssd(-10, 0x00000000)
+    with open("ssd_output.txt", 'r', encoding='utf-8') as file:
+        assert file.read() == "ERROR"
 
 
 def test_ssd_write_error_index_above_99():
@@ -84,6 +92,8 @@ def test_ssd_write_error_index_above_99():
         ssd.write_ssd(1000, 0x00000000)
     with pytest.raises(ValueError, match="ERROR"):
         ssd.write_ssd(10000, 0x00000000)
+    with open("ssd_output.txt", 'r', encoding='utf-8') as file:
+        assert file.read() == "ERROR"
 
 
 def test_ssd_write_error_not_digit():
@@ -92,12 +102,16 @@ def test_ssd_write_error_not_digit():
         ssd.write_ssd("abc", 0x00000000)
     with pytest.raises(ValueError, match="ERROR"):
         ssd.write_ssd(3, "0xABCD0000")
+    with open("ssd_output.txt", 'r', encoding='utf-8') as file:
+        assert file.read() == "ERROR"
 
 
 def test_ssd_write_error_minus_value():
     ssd = SSD()
     with pytest.raises(ValueError, match="ERROR"):
         ssd.write_ssd(10, -1)
+    with open("ssd_output.txt", 'r', encoding='utf-8') as file:
+        assert file.read() == "ERROR"
 
 
 def test_ssd_write_error_value_above_32bits():
@@ -106,3 +120,5 @@ def test_ssd_write_error_value_above_32bits():
         ssd.write_ssd(10, 0x100000000)
     with pytest.raises(ValueError, match="ERROR"):
         ssd.write_ssd(10, 0x300000000)
+    with open("ssd_output.txt", 'r', encoding='utf-8') as file:
+        assert file.read() == "ERROR"


### PR DESCRIPTION
[Problem] 1. read_ssd function 내에 invalid input check 수행 함수 없음
                 2. SSD ERROR 시에 ssd_output.txt 에 ERROR 를 출력하는 기능 없음
[Solution] 1. read_ssd function 내에 invalid input check 수행 함수 추가 및 refactoring
                 2. SSD ERROR 시에 ssd_output.txt 에 ERROR 를 출력하는 기능 추가