### PR TITLE
[Refactoring] Change SSDNand & SSDOutput class as Singleton

### DIFF
--- a/ssd.py
+++ b/ssd.py
@@ -52,13 +52,22 @@ class SSD():
 
 
 class SSDNand:
-    def __init__(self):
-        ssd_nand_txt = []
-        for i in range(0, 100):
-            newline = f"{i:02d} 0x00000000\n"
-            ssd_nand_txt.append(newline)
+    _instance = None
 
-        self.write(ssd_nand_txt)
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if not hasattr(self, 'initialized'):
+            ssd_nand_txt = []
+            for i in range(0, 100):
+                newline = f"{i:02d} 0x00000000\n"
+                ssd_nand_txt.append(newline)
+
+            self.write(ssd_nand_txt)
+            self.initialized = True
 
     def read(self):
         with open("ssd_nand.txt", 'r', encoding='utf-8') as file:
@@ -73,8 +82,17 @@ class SSDNand:
             file.writelines(output)
 
 class SSDOutput:
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
     def __init__(self):
-        self.write("")
+        if not hasattr(self, 'initialized'):
+            self.write("")
+            self.initialized = True
 
     def read(self):
         with open("ssd_output.txt", 'r', encoding='utf-8') as file:

--- a/test_ssd.py
+++ b/test_ssd.py
@@ -180,3 +180,16 @@ def test_ssd_read_output(mocker: MockerFixture):
     assert ssd._output_txt.write.call_count == 1
 
 
+@pytest.mark.parametrize("output", [["ERROR"], ["10 0x00000000"], ["20 0x00000000"]])
+def test_singletone_ssd_nand(output):
+    ssd_output = SSDNand()
+    ssd_output.write(output)
+    ssd_new_output = SSDNand()
+    assert ssd_output.read() == ssd_new_output.read()
+
+@pytest.mark.parametrize("output", ["ERROR", "10 0x00000000", "20 0x00000000"])
+def test_singletone_ssd_output(output):
+    ssd_output = SSDOutput()
+    ssd_output.write(output)
+    ssd_new_output = SSDOutput()
+    assert ssd_output.read() == ssd_new_output.read()


### PR DESCRIPTION
[Problem] SSD class 가 생성 될 때마다, ssd_nand.txt &  ssd_output.txt file이 초기화 됨
[Solution] SSDNand, SSDOutput class 를 Singleton 으로 변경
