### PR TITLE
[Refactoring] use ssd command in shell

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -39,7 +39,7 @@ class shell_ftn():
         offset = 0
         while size > 0:
             erase_size = min(size, 10)
-            SSD.erase_ssd(lba + offset, erase_size)
+            self._send_command(lba + offset, erase_size)
             offset += 10
             size -= erase_size
 

--- a/shell.py
+++ b/shell.py
@@ -57,7 +57,7 @@ class shell_ftn():
         offset = 0
         while size > 0:
             erase_size = min(size, 10)
-            self._send_command(lba + offset, erase_size)
+            self._send_command('E', lba + offset, erase_size)
             offset += 10
             size -= erase_size
         self.logger.print(f"{self.read.__qualname__}()", "DONE")

--- a/shell.py
+++ b/shell.py
@@ -11,7 +11,9 @@ class shell_ftn():
 
     def _send_command(self, command, lba, value = None):
         if (command == 'W'):
-            return self.ssd.run([None, 'W', lba, hex(value).upper()])
+            if type(value) is int:
+                value = hex(value).upper()
+            return self.ssd.run([None, 'W', lba, value])
         if (command == 'R'):
             return self.ssd.run([None, 'R', lba])
         if (command == 'E'):
@@ -23,8 +25,8 @@ class shell_ftn():
         value = result.split()[1]
         print(f'[Read] LBA {idx}: {value}')
 
-    def write(self, num: int, value: str) -> None:
-        self.ssd.write_ssd(num, value)
+    def write(self, num: int, value: int) -> None:
+        self._send_command('W', num, value)
         if self.ssd_output.read() == '':
             print('[Write] Done')
             return True
@@ -62,7 +64,7 @@ class shell_ftn():
 
     def fullwrite(self, value):
         for x in range(100):
-            self.ssd.write_ssd(x, value)
+            self._send_command('W', x, value)
         print("[Full Write] Done")
 
     def fullread(self):
@@ -87,7 +89,7 @@ class shell_ftn():
             for x in range(5):
                 rand_num = random.randint(0, 0xFFFFFFFF)
                 hex_str = f"0x{rand_num:08X}"
-                self.ssd.write_ssd(start_idx + x, rand_num)
+                self._send_command('W', start_idx + x, rand_num)
                 if self.ssd_nand.readline(start_idx + x).split()[1] != hex_str:
                     print('FAIL')
                     return
@@ -98,7 +100,7 @@ class shell_ftn():
         for _ in range(30):
             random_write_value = random.randint(0, 0xFFFFFFFF)
             for x in range(5):
-                self.ssd.write_ssd(partialLBA_index_list[x], random_write_value)
+                self._send_command('W', partialLBA_index_list[x], random_write_value)
             check_ref = self.ssd_nand.readline(0).split()[1]
             for x in range(1, 5):
                 if check_ref != self.ssd_nand.readline(x).split()[1]:
@@ -109,8 +111,8 @@ class shell_ftn():
     def WriteReadAging(self):
         value = random.randint(0, 0xFFFFFFFF)
         for i in range(200):
-            self.ssd.write_ssd(0, value)
-            self.ssd.write_ssd(99, value)
+            self._send_command('W', 0, value)
+            self._send_command('W', 99, value)
             if self.ssd_nand.readline(0).split()[1] != self.ssd_nand.readline(99).split()[1]:
                 print('FAIL')
                 return

--- a/shell.py
+++ b/shell.py
@@ -9,8 +9,16 @@ class shell_ftn():
         self.ssd_output = SSDOutput()
         self.ssd_nand = SSDNand()
 
+    def _send_command(self, command, lba, value = None):
+        if (command == 'W'):
+            return self.ssd.run([None, 'W', lba, hex(value).upper()])
+        if (command == 'R'):
+            return self.ssd.run([None, 'R', lba])
+        if (command == 'E'):
+            return self.ssd.run([None, 'E', lba, value])
+
     def read(self, idx: int) -> None:
-        self.ssd.read_ssd(idx)
+        self._send_command('R', idx)
         result = self.ssd_output.read()
         value = result.split()[1]
         print(f'[Read] LBA {idx}: {value}')
@@ -62,7 +70,7 @@ class shell_ftn():
 
         for idx in range(100):
             try:
-                self.ssd.read_ssd(idx)
+                self._send_command('R', idx)
                 output = self.ssd_output.read()
 
                 if output == "ERROR" or len(output.split()) < 2:

--- a/test_shell.py
+++ b/test_shell.py
@@ -11,10 +11,10 @@ def shell():
     return shell_ftn()
 
 
-@pytest.mark.parametrize("index", ['1 10', '2 20'])
-def test_read(shell, mocker: MockerFixture, index):
+@pytest.mark.parametrize("index, output", [(1, '1 10'), (2, '2 20')])
+def test_read(shell, mocker: MockerFixture, index, output):
     mock_read_ssd = mocker.patch.object(shell.ssd, 'read_ssd')
-    mock_read_output = mocker.patch.object(shell.ssd_output, 'read', return_value=index)
+    mock_read_output = mocker.patch.object(shell.ssd_output, 'read', return_value=output)
     mock_print = mocker.patch('builtins.print')
 
     shell.read(index)


### PR DESCRIPTION
[Problem] shell.py에서 ssd.py의 API를 직접 call 하는 식으로 되어 있어 buffer 사용시 제약이 있을 것으로 예상 됨
[Solution] command를 활용 하도록 변경