### PR TITLE
[Fix] Nand Init value change

### DIFF
--- a/ssd_texts.py
+++ b/ssd_texts.py
@@ -24,7 +24,7 @@ class SSDNand(SSDText):
             self.initialized = True
             ssd_nand_txt = []
             for i in range(0, MAX_NAND_SIZE):
-                newline = f"{i:02d} 0xBABOBABO\n"
+                newline = f"{i:02d} 0x0000000O\n"
                 ssd_nand_txt.append(newline)
             self.write(ssd_nand_txt)
 


### PR DESCRIPTION
[Problem] ssd_nand.txt 의 초기값이 잘못 설정 되어 있음
[Solution] ssd_nand.txt 의 초기값을 0으로 설정
